### PR TITLE
Kafka 0.8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.1</version>
 
     <properties>
-        <kafka.version>0.8.1.1</kafka.version>
-        <scala.version>2.8.0</scala.version>
+        <kafka.version>0.8.2.1</kafka.version>
+        <scala.version>2.10</scala.version>
         <hadoop.version>2.2.0</hadoop.version>
         <guava.version>12.0.1</guava.version>
         <slf4j.version>1.6.1</slf4j.version>
@@ -20,18 +20,8 @@
         <!-- Kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.8.0</artifactId>
+            <artifactId>kafka_${scala.version}</artifactId>
             <version>${kafka.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
         </dependency>
 
         <!-- Hadoop -->
@@ -65,6 +55,13 @@
             <version>2.1</version>
         </dependency>
 
+        <!-- json.org -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20140107</version>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -92,6 +89,12 @@
             <version>4.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>info.batey.kafka</groupId>
+            <artifactId>kafka-unit</artifactId>
+            <version>0.1.4-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -100,8 +103,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,9 @@
 
         <!-- Zookeeper -->
         <dependency>
-            <groupId>com.github.sgroschupf</groupId>
+            <groupId>com.101tec</groupId>
             <artifactId>zkclient</artifactId>
-            <version>0.1</version>
+            <version>0.6</version>
         </dependency>
 
         <!-- Testing -->

--- a/src/main/java/com/conductor/kafka/hadoop/KafkaInputFormat.java
+++ b/src/main/java/com/conductor/kafka/hadoop/KafkaInputFormat.java
@@ -226,6 +226,9 @@ public class KafkaInputFormat extends InputFormat<LongWritable, BytesWritable> {
         for (final long offset : allOffsets) {
             if (offset > lastCommit && offset > includeAfter) {
                 result.add(offset);
+            } else if (lastCommit == -1L) {
+                // nothing commited yet, so consume everything
+                result.add(offset);
             } else {
                 // we add "lastCommit" iff it is after "includeAfter"
                 if (lastCommit > includeAfter) {

--- a/src/main/java/com/conductor/kafka/hadoop/KafkaInputFormat.java
+++ b/src/main/java/com/conductor/kafka/hadoop/KafkaInputFormat.java
@@ -219,20 +219,21 @@ public class KafkaInputFormat extends InputFormat<LongWritable, BytesWritable> {
         final OffsetRequest requestBeforeAsOf = toOffsetRequest(topic, partitionNum, asOfTime, 1, conf);
         final OffsetResponse offsetsBeforeAsOfResponse = consumer.getOffsetsBefore(requestBeforeAsOf);
         final long[] offsetsBeforeAsOf = offsetsBeforeAsOfResponse.offsets(topic, partitionNum);
-        final long includeAfter = offsetsBeforeAsOf.length == 1 ? offsetsBeforeAsOf[0] : 0;
+        final long includeAfter = offsetsBeforeAsOf.length == 1 ? offsetsBeforeAsOf[0] : -1;
 
         // note that the offsets are in descending order
         List<Long> result = Lists.newArrayList();
+        System.out.println("allOffsets: " + Arrays.toString(allOffsets));
         for (final long offset : allOffsets) {
             if (offset > lastCommit && offset > includeAfter) {
                 result.add(offset);
-            } else if (lastCommit == -1L) {
+            } else if (lastCommit == -1L && offset > includeAfter) {
                 // nothing commited yet, so consume everything
                 result.add(offset);
             } else {
-                // we add "lastCommit" iff it is after "includeAfter"
+                // we add "lastCommit" if it is after "includeAfter"
                 if (lastCommit > includeAfter) {
-                    result.add(lastCommit);
+                    result.add(lastCommit +1);
                 }
                 // we can break out of loop here bc offsets are in desc order, and we've hit the latest one to include
                 break;

--- a/src/main/java/com/conductor/kafka/hadoop/KafkaInputFormat.java
+++ b/src/main/java/com/conductor/kafka/hadoop/KafkaInputFormat.java
@@ -175,13 +175,13 @@ public class KafkaInputFormat extends InputFormat<LongWritable, BytesWritable> {
                 // cache the consumer connections - each partition will make use of each broker consumer
                 final Broker broker = partition.getBroker();
                 if (!consumers.containsKey(broker)) {
-                    consumers.put(broker, getConsumer(broker));
+                    consumers.put(broker, getConsumer(broker, conf));
                 }
 
                 // grab all valid offsets
                 final List<Long> offsets = getOffsets(consumers.get(broker), topic, partition.getPartId(),
                         zk.getLastCommit(group, partition), getIncludeOffsetsAfterTimestamp(conf),
-                        getMaxSplitsPerPartition(conf));
+                        getMaxSplitsPerPartition(conf), conf);
                 for (int i = 0; i < offsets.size() - 1; i++) {
                     // ( offsets in descending order )
                     final long start = offsets.get(i + 1);
@@ -206,17 +206,17 @@ public class KafkaInputFormat extends InputFormat<LongWritable, BytesWritable> {
 
     @VisibleForTesting
     List<Long> getOffsets(final SimpleConsumer consumer, final String topic, final int partitionNum,
-            final long lastCommit, final long asOfTime, final int maxSplitsPerPartition) {
+            final long lastCommit, final long asOfTime, final int maxSplitsPerPartition, final Configuration conf) {
         // TODO: take advantage of new API, which allows you to request offsets for multiple topic-partitions.
 
         // all offsets that exist for this partition (in descending order)
         final OffsetRequest allReq = toOffsetRequest(topic, partitionNum, kafka.api.OffsetRequest.LatestTime(),
-                Integer.MAX_VALUE);
+                Integer.MAX_VALUE, conf);
         final OffsetResponse allOffsetsResponse = consumer.getOffsetsBefore(allReq);
         final long[] allOffsets = allOffsetsResponse.offsets(topic, partitionNum);
 
         // this gets us an offset that is strictly before 'asOfTime', or zero if none exist before that time
-        final OffsetRequest requestBeforeAsOf = toOffsetRequest(topic, partitionNum, asOfTime, 1);
+        final OffsetRequest requestBeforeAsOf = toOffsetRequest(topic, partitionNum, asOfTime, 1, conf);
         final OffsetResponse offsetsBeforeAsOfResponse = consumer.getOffsetsBefore(requestBeforeAsOf);
         final long[] offsetsBeforeAsOf = offsetsBeforeAsOfResponse.offsets(topic, partitionNum);
         final long includeAfter = offsetsBeforeAsOf.length == 1 ? offsetsBeforeAsOf[0] : 0;
@@ -248,12 +248,13 @@ public class KafkaInputFormat extends InputFormat<LongWritable, BytesWritable> {
 
     @VisibleForTesting
     static OffsetRequest toOffsetRequest(final String topic, final int partitionNum, final long asOfTime,
-            final int numOffsets) {
+            final int numOffsets, final Configuration conf) {
         final TopicAndPartition topicAndPartition = new TopicAndPartition(topic, partitionNum);
         final PartitionOffsetRequestInfo partitionInfoReq = new PartitionOffsetRequestInfo(asOfTime, numOffsets);
         final Map<TopicAndPartition, PartitionOffsetRequestInfo> requestInfo = ImmutableMap.of(topicAndPartition,
                 partitionInfoReq);
-        return new OffsetRequest(requestInfo, kafka.api.OffsetRequest.CurrentVersion(), "KafkaInputFormat");
+        return new OffsetRequest(requestInfo, kafka.api.OffsetRequest.CurrentVersion(),
+                KafkaInputFormat.getConsumerGroup(conf));
     }
 
     /*
@@ -261,9 +262,9 @@ public class KafkaInputFormat extends InputFormat<LongWritable, BytesWritable> {
      */
 
     @VisibleForTesting
-    SimpleConsumer getConsumer(final Broker broker) {
+    SimpleConsumer getConsumer(final Broker broker, final Configuration conf) {
         return new SimpleConsumer(broker.getHost(), broker.getPort(), DEFAULT_SOCKET_TIMEOUT_MS,
-                DEFAULT_BUFFER_SIZE_BYTES, "KafkaInputFormat");
+                DEFAULT_BUFFER_SIZE_BYTES, KafkaInputFormat.getConsumerGroup(conf));
     }
 
     @VisibleForTesting

--- a/src/main/java/com/conductor/kafka/hadoop/KafkaRecordReader.java
+++ b/src/main/java/com/conductor/kafka/hadoop/KafkaRecordReader.java
@@ -160,7 +160,7 @@ public class KafkaRecordReader extends RecordReader<LongWritable, BytesWritable>
      */
     @VisibleForTesting
     boolean continueItr() {
-        final long remaining = end - pos -1;
+        final long remaining = end - pos -1; // we exclude the last element. A split 10-20 means elements from 10 to 19.
         if (!canCallNext() && remaining > 0) {
             LOG.debug(String.format("%s fetching %d bytes starting at offset %d",
                     split.toString(), fetchSize, pos));
@@ -168,7 +168,7 @@ public class KafkaRecordReader extends RecordReader<LongWritable, BytesWritable>
             final int partition = split.getPartition().getPartId();
             final FetchRequest request = new FetchRequestBuilder()
                     .addFetch(topic, partition, pos, fetchSize)
-                    .clientId("KafkaRecordReader")
+                    .clientId(KafkaInputFormat.getConsumerGroup(conf))
                     .build();
             final FetchResponse fetchResponse = consumer.fetch(request);
             if (fetchResponse.hasError()) {

--- a/src/main/java/com/conductor/kafka/hadoop/KafkaRecordReader.java
+++ b/src/main/java/com/conductor/kafka/hadoop/KafkaRecordReader.java
@@ -214,7 +214,8 @@ public class KafkaRecordReader extends RecordReader<LongWritable, BytesWritable>
     @VisibleForTesting
     SimpleConsumer getConsumer(final KafkaInputSplit split, final Configuration conf) {
         return new SimpleConsumer(split.getPartition().getBroker().getHost(), split.getPartition().getBroker()
-                .getPort(), getKafkaSocketTimeoutMs(conf), getKafkaBufferSizeBytes(conf), "kafkaInputFormat");
+                .getPort(), getKafkaSocketTimeoutMs(conf), getKafkaBufferSizeBytes(conf),
+                KafkaInputFormat.getConsumerGroup(conf));
     }
 
     @VisibleForTesting

--- a/src/main/java/com/conductor/kafka/zk/ZkUtils.java
+++ b/src/main/java/com/conductor/kafka/zk/ZkUtils.java
@@ -171,9 +171,7 @@ public class ZkUtils implements Closeable {
 
     /**
      * Checks whether the provided partition exists on the {@link Broker}.
-     * 
-     * @param broker
-     *            the broker.
+     *
      * @param topic
      *            the topic.
      * @param partId

--- a/src/test/java/com/conductor/kafka/IntTestBase.java
+++ b/src/test/java/com/conductor/kafka/IntTestBase.java
@@ -1,0 +1,57 @@
+package com.conductor.kafka;
+
+import info.batey.kafka.unit.KafkaUnit;
+import kafka.producer.KeyedMessage;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Integration test base class. Includes Kafka and Zookeeper instances
+ *
+ * Created by Greg Temchenko on 10/5/15.
+ */
+public class IntTestBase {
+
+    final static protected String TEST_TOPIC = "test-topic";
+    final static protected String TEST_GROUP = "test-group";
+    final static protected int NUMBER_EVENTS = 100;
+
+    protected static KafkaUnit kafka = null;
+
+    static protected int kafkaPort;
+    static protected int zkPort;
+
+    @BeforeClass
+    static public void setUp() {
+        // embedded kafka + zookeeper, thus we
+        zkPort = 11111;
+        kafkaPort = 11112; // TODO pick dynamically so can run in parallel on the same machine
+        kafka = new KafkaUnit(zkPort, kafkaPort);
+
+        // use small segments to test multiple segments with smaller amount of records
+        kafka.setKafkaBrokerConfig("log.segment.bytes", "1024");
+
+        kafka.startup();
+
+        // create new topic and put some test messages
+        kafka.createTopic(TEST_TOPIC);
+
+        for (int i = 1; i <= NUMBER_EVENTS; i++) {
+            KeyedMessage<String, String> keyedMessage = new KeyedMessage<>(TEST_TOPIC,
+                    "test-key-" + Integer.valueOf(i), getMessageBody(i));
+            kafka.sendMessages(keyedMessage);
+        }
+    }
+
+    @AfterClass
+    static public void tearDown() throws Exception {
+        if (kafka != null) {
+            kafka.shutdown();
+        }
+    }
+
+    static protected String getMessageBody(Integer messageNumber) {
+        return "test-message-" + String.format("%05d", messageNumber);
+    }
+
+}

--- a/src/test/java/com/conductor/kafka/IntTestBase.java
+++ b/src/test/java/com/conductor/kafka/IntTestBase.java
@@ -23,17 +23,23 @@ public class IntTestBase {
 
     @BeforeClass
     static public void setUp() {
-        // embedded kafka + zookeeper, thus we
+        // Embedded kafka + zookeeper
         zkPort = 11111;
         kafkaPort = 11112; // TODO pick dynamically so can run in parallel on the same machine
         kafka = new KafkaUnit(zkPort, kafkaPort);
 
-        // use small segments to test multiple segments with smaller amount of records
+        // Use small segments to test multiple segments with smaller amount of records
         kafka.setKafkaBrokerConfig("log.segment.bytes", "1024");
+
+        // Flush data often so we don't have moments when we verify results that's not been flushed yet.
+        // Makes performance bad, but reliable results.
+        kafka.setKafkaBrokerConfig("log.flush.interval.messages", "1");
+        kafka.setKafkaBrokerConfig("log.flush.scheduler.interval.ms", "100");
+        kafka.setKafkaBrokerConfig("log.flush.interval.ms", "100");
 
         kafka.startup();
 
-        // create new topic and put some test messages
+        // Create new topic and put some test messages
         kafka.createTopic(TEST_TOPIC);
 
         for (int i = 1; i <= NUMBER_EVENTS; i++) {
@@ -51,6 +57,7 @@ public class IntTestBase {
     }
 
     static protected String getMessageBody(Integer messageNumber) {
+        // Zeros padding makes messages possible to sort just by its string values
         return "test-message-" + String.format("%05d", messageNumber);
     }
 

--- a/src/test/java/com/conductor/kafka/hadoop/KafkaInputFormatIntTest.java
+++ b/src/test/java/com/conductor/kafka/hadoop/KafkaInputFormatIntTest.java
@@ -1,0 +1,44 @@
+package com.conductor.kafka.hadoop;
+
+import com.conductor.kafka.IntTestBase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobContextImpl;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobID;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Greg Temchenko on 10/5/15.
+ */
+public class KafkaInputFormatIntTest extends IntTestBase {
+
+    @Test
+    public void getAllSplits() throws Exception {
+        KafkaInputFormat kafkaInputFormat = new KafkaInputFormat();
+
+        Configuration conf = new Configuration();
+        conf.set("kafka.zk.connect", "localhost:" + Integer.valueOf(zkPort));
+        conf.set("kafka.topic", TEST_TOPIC);
+        conf.set("kafka.groupid", TEST_GROUP);
+
+        JobConf jobConf = new JobConf(conf);
+        JobContext jobContext = new JobContextImpl(jobConf, JobID.forName("job_test_123"));
+        List<InputSplit> splits = kafkaInputFormat.getSplits(jobContext);
+
+        // check
+        assert splits.size() > 0;
+
+        int sum = 0;
+        for (InputSplit split : splits) {
+            sum += split.getLength();
+        }
+        assertEquals(100, sum);
+    }
+
+}

--- a/src/test/java/com/conductor/kafka/hadoop/KafkaInputFormatTest.java
+++ b/src/test/java/com/conductor/kafka/hadoop/KafkaInputFormatTest.java
@@ -167,7 +167,7 @@ public class KafkaInputFormatTest {
         final int lastCommit = 52;
         expected = new long[6];
         System.arraycopy(offsets, 0, expected, 0, 6);
-        expected[5] = lastCommit;
+        expected[5] = lastCommit +1;
         actual = inputFormat.getOffsets(consumer, "topic", 1, lastCommit, 0, Integer.MAX_VALUE, mockConf);
         compareArrayContents(expected, actual);
 

--- a/src/test/java/com/conductor/kafka/hadoop/KafkaRecordReaderIntTest.java
+++ b/src/test/java/com/conductor/kafka/hadoop/KafkaRecordReaderIntTest.java
@@ -1,0 +1,80 @@
+package com.conductor.kafka.hadoop;
+
+import com.conductor.kafka.IntTestBase;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobContextImpl;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Greg Temchenko on 10/6/15.
+ */
+public class KafkaRecordReaderIntTest extends IntTestBase {
+
+    @Test
+    public void readingTest() throws Exception {
+        // config
+        KafkaInputFormat kafkaInputFormat = new KafkaInputFormat();
+
+        Configuration conf = new Configuration();
+        conf.set("kafka.zk.connect", "localhost:" + Integer.valueOf(zkPort));
+        conf.set("kafka.topic", TEST_TOPIC);
+        conf.set("kafka.groupid", TEST_GROUP);
+
+        JobConf jobConf = new JobConf(conf);
+        JobContext jobContext = new JobContextImpl(jobConf, JobID.forName("job_test_123"));
+        List<InputSplit> splits = kafkaInputFormat.getSplits(jobContext);
+
+        assert splits.size() > 0 : "No input splits generated";
+        assert splits.size() > 1 : "There should be more than one splits to test it appropriately";
+
+        // read every split
+        List<String> readEvents = new ArrayList<>();
+        for (InputSplit split : splits) {
+            TaskAttemptContext attemptContext = new TaskAttemptContextImpl(conf, TaskAttemptID.forName("attempt_test_123_m12_34_56"));
+
+            RecordReader recordReader = kafkaInputFormat.createRecordReader(split, attemptContext);
+            recordReader.initialize(split, attemptContext);
+
+            // check
+            while (recordReader.nextKeyValue()) {
+                assert recordReader.getCurrentKey() != null;
+                assert recordReader.getCurrentValue() != null;
+                assert recordReader.getCurrentValue() instanceof BytesWritable;
+
+                BytesWritable bytesWritable = (BytesWritable) recordReader.getCurrentValue();
+                String kafkaEvent = new String(
+                        java.util.Arrays.copyOfRange(bytesWritable.getBytes(), 0, bytesWritable.getLength()), StandardCharsets.UTF_8);
+
+                readEvents.add(kafkaEvent);
+            }
+        }
+
+        assertEquals(NUMBER_EVENTS, readEvents.size());
+
+        // Messages returns in order within a partition. So we sort all read messages
+        // and check there are no dups or unexpected events
+        Collections.sort(readEvents);
+        for (int i=0; i<NUMBER_EVENTS; i++) {
+            assertEquals("Incorrect message. Maybe there are duplicates or unexpected events?",
+                    getMessageBody(i+1), readEvents.get(i));
+        }
+    }
+
+}

--- a/src/test/java/com/conductor/kafka/hadoop/KafkaRecordReaderTest.java
+++ b/src/test/java/com/conductor/kafka/hadoop/KafkaRecordReaderTest.java
@@ -97,7 +97,7 @@ public class KafkaRecordReaderTest {
         assertEquals(0, reader.getStart());
         assertEquals(100, reader.getEnd());
         assertEquals(0, reader.getPos());
-        assertEquals(0, reader.getCurrentOffset());
+        assertEquals(0, reader.getPos());
         assertNull("Iterator should not have been initialized yet!", reader.getCurrentMessageItr());
         assertNull("Current key should be null!", reader.getCurrentKey());
         assertNull("Current value should be null!", reader.getCurrentValue());
@@ -152,7 +152,7 @@ public class KafkaRecordReaderTest {
                 assertTrue(reqInfo.contains(topicAndPartition));
                 final Option<PartitionFetchInfo> fetchInfo = reqInfo.get(topicAndPartition);
                 assertEquals(0, fetchInfo.get().offset());
-                assertEquals(100, fetchInfo.get().fetchSize());
+                assertEquals(2048, fetchInfo.get().fetchSize());
                 return fetchResponse;
             }
         });
@@ -164,7 +164,6 @@ public class KafkaRecordReaderTest {
 
         assertTrue("Should be able to continue iterator!", reader.continueItr());
         assertEquals(mockIterator, reader.getCurrentMessageItr());
-        assertEquals(100, reader.getCurrentOffset());
 
         when(mockIterator.hasNext()).thenReturn(false);
         assertFalse("Should be done with split!", reader.continueItr());

--- a/src/test/java/com/conductor/kafka/zk/ZkUtilsIntTest.java
+++ b/src/test/java/com/conductor/kafka/zk/ZkUtilsIntTest.java
@@ -1,0 +1,92 @@
+package com.conductor.kafka.zk;
+
+import com.conductor.kafka.Broker;
+import com.conductor.kafka.IntTestBase;
+import com.conductor.kafka.Partition;
+import com.conductor.kafka.hadoop.KafkaInputFormat;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Integration test reading the config written by kafka to zookeeper.
+ *
+ * Created by Greg Temchenko on 10/2/15.
+ */
+public class ZkUtilsIntTest extends IntTestBase {
+
+    static protected ZkUtils zkUtils;
+
+    @BeforeClass
+    static public void setUpTest() {
+        // the client that we test
+        zkUtils = new ZkUtils("localhost:" + zkPort,
+                KafkaInputFormat.DEFAULT_ZK_ROOT,
+                KafkaInputFormat.DEFAULT_ZK_SESSION_TIMEOUT_MS,
+                KafkaInputFormat.DEFAULT_ZK_CONNECTION_TIMEOUT_MS);
+    }
+
+    @Test
+    public void getBrokers() {
+//        SimpleConsumer consumer = new SimpleConsumer("localhost", kafkaPort, 100000, 64 * 1024, "testClientId");
+
+        // check getBrokers()
+        List<Broker> brokerList = zkUtils.getBrokers();
+        assert brokerList.size() > 0;
+        assert brokerList.get(0).getHost().equals("localhost");
+        assert brokerList.get(0).getPort() == kafkaPort;
+
+        // check getBroker()
+        Integer id = brokerList.get(0).getId();
+        Broker broker = zkUtils.getBroker(id);
+        assert brokerList.get(0).getHost().equals(broker.getHost());
+        assert brokerList.get(0).getPort() == broker.getPort();
+        assert brokerList.get(0).getId() == id;
+    }
+
+    @Test
+    public void getPartitions() {
+        // check getPartitions()
+        List<Partition> partitions = zkUtils.getPartitions(TEST_TOPIC);
+
+        assert partitions.size() > 0;
+        Partition part = partitions.get(0);
+        assert part.getPartId() == 0;
+        assert part.getTopic().equals(TEST_TOPIC);
+        assert part.getBroker().getHost().equals("localhost");
+        assert part.getBroker().getPort() == kafkaPort;
+
+        // check partitionExists()
+        assert zkUtils.partitionExists(TEST_TOPIC, part.getPartId());
+        assert ! zkUtils.partitionExists(TEST_TOPIC, 99999);
+    }
+
+    @Test
+    public void commit() {
+        List<Partition> partitions = zkUtils.getPartitions(TEST_TOPIC);
+        Partition part = partitions.get(0);
+
+        // check getLastCommit()
+        Long lastCommit = zkUtils.getLastCommit(TEST_GROUP, part);
+        assert lastCommit == -1L;
+
+        // check temporary setLastCommit(), not commited so getLastCommit() == -1L
+        zkUtils.setLastCommit(TEST_GROUP, part, 10, true);
+        lastCommit = zkUtils.getLastCommit(TEST_GROUP, part);
+        assert lastCommit == -1L;
+
+        // commit the change
+        zkUtils.commit(TEST_GROUP, TEST_TOPIC);
+
+        // check committed
+        lastCommit = zkUtils.getLastCommit(TEST_GROUP, part);
+        assert lastCommit == 10L;
+
+        // check not temporary setLastCommit()
+        zkUtils.setLastCommit(TEST_GROUP, part, 20, false);
+        lastCommit = zkUtils.getLastCommit(TEST_GROUP, part);
+        assert lastCommit == 20L;
+    }
+
+}


### PR DESCRIPTION
These changes make Kangaroo compatible with kafka 0.8. I wrote some integration tests which use the project kafka-unit to spin up real kafka and zookeeper instances, so it's tested against real servers, not mocks and it makes debugging much easier.

The changes depend on this pull request in kafka-unit: https://github.com/chbatey/kafka-unit/pull/12

I also tested it manually with real MR jobs.
Please let me know if I can help any more with reviewing this. I would like to push it upstream, so I wouldn't need to keep a fork of the project in my company. Though no rush. We could chat if it helps, or ask me any questions.

Thank you!